### PR TITLE
Fix console warn for users that have not set a default language in their profile

### DIFF
--- a/src/localize.ts
+++ b/src/localize.ts
@@ -60,7 +60,7 @@ export default function localize(
   let langStored: string | null = null;
 
   try {
-    langStored = JSON.parse(localStorage.getItem('selectedLanguage') ?? '');
+    langStored = JSON.parse(localStorage.getItem('selectedLanguage') ?? '""');
   } catch (e) {
     console.warn(e);
     langStored = localStorage.getItem('selectedLanguage');


### PR DESCRIPTION
JSON.parse expects string in JSON format, else lots of console warns on page loading if user has not set language via user profile UI